### PR TITLE
Fixed testing to check with sources and not installed package

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pseutopy.pseutopy import PseuToPy
+from src.pseutopy.pseutopy import PseuToPy
 
 
 @pytest.fixture(scope="session")

--- a/src/pseutopy/pseutopy.py
+++ b/src/pseutopy/pseutopy.py
@@ -3,14 +3,14 @@ import os
 
 from textx import metamodel_from_file
 
-from pseutopy.generators.expressions import Factor, UnaryOp, NotTest, \
+from src.pseutopy.generators.expressions import Factor, UnaryOp, NotTest, \
     BinaryOp, OrTest, AndTest, Comparison, TestList, Expr, XorExpr, AndExpr, \
     ShiftExpr, ArithExpr, Term, Power, TestListStarExpr, AtomExpr, Atom, \
     Parameters, TypedArgsList
-from pseutopy.generators.statements import Statement, ExprStmt, \
+from src.pseutopy.generators.statements import Statement, ExprStmt, \
     InputStmt, FuncCallStmt, DeclareStmt, PrintStmt, DelStmt, IfStmt, \
     WhileStmt, ForStmt, FuncDef, ReturnStmt
-from pseutopy.generators.values import Number, Name, String, NoneType, \
+from src.pseutopy.generators.values import Number, Name, String, NoneType, \
     Boolean
 
 


### PR DESCRIPTION
Before: Was testing with the package installed with `pip install -e .`.

Now: Tests with the `src` files.