### PR TITLE
[PTP-015] Fixed whitespaces between keywords and :

### DIFF
--- a/src/pseutopy/grammars/en.lark
+++ b/src/pseutopy/grammars/en.lark
@@ -80,10 +80,10 @@ assert_stmt: "assert" test ["," test]
 
 compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | with_stmt | funcdef | classdef | decorated | async_stmt
 async_stmt: "async" (funcdef | with_stmt | for_stmt)
-if_stmt: "if" test (":" | "then" | "then:") suite (elif_stmt test (":" | "then" | "then:") suite)* ["else" (":" | "then" | "then:") suite]
+if_stmt: "if" test (":" | "then" | "then" ":") suite (elif_stmt test (":" | "then" | "then" ":") suite)* ["else" (":" | "then" | "then" ":") suite]
 elif_stmt : ("elif" | "else" "if") -> elseif
-while_stmt: "while" test (":" | "do" | "do:") suite ["else" (":" | "do" | "do:") suite]
-for_stmt: "for" exprlist "in" testlist (":" | "do" | "do:") suite ["else" (":" | "do" | "do:") suite]
+while_stmt: "while" test (":" | "do" | "do" ":") suite ["else" (":" | "do" | "do" ":") suite]
+for_stmt: "for" exprlist "in" testlist (":" | "do" | "do" ":") suite ["else" (":" | "do" | "do" ":") suite]
 try_stmt: ("try" ":" suite ((except_clause ":" suite)+ ["else" ":" suite] ["finally" ":" suite] | "finally" ":" suite))
 with_stmt: "with" with_item ("," with_item)*  ":" suite
 with_item: test ["as" expr]

--- a/src/pseutopy/grammars/fr.lark
+++ b/src/pseutopy/grammars/fr.lark
@@ -80,10 +80,10 @@ assert_stmt: "assert" test ["," test]
 
 compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | with_stmt | funcdef | classdef | decorated | async_stmt
 async_stmt: "async" (funcdef | with_stmt | for_stmt)
-if_stmt: ("if" | "si") test (":" | "alors" | "alors:") suite (elif_stmt test (":" | "alors" | "alors:") suite)* ["sinon" (":" | "alors" | "alors:") suite]
+if_stmt: ("if" | "si") test (":" | "alors" | "alors" ":") suite (elif_stmt test (":" | "alors" | "alors" ":") suite)* ["sinon" (":" | "alors" | "alors" ":") suite]
 elif_stmt : ("elif" | "sinon" "si") -> elseif
-while_stmt: ("while" | "tant" "que") test (":" | "faire" | "faire:") suite [("else" | "sinon") (":" | "faire" | "faire:") suite]
-for_stmt: ("for" | "pour") exprlist ("in" | "dans") testlist (":" | "faire" | "faire:") suite [("else" | "sinon") (":" | "faire" | "faire:") suite]
+while_stmt: ("while" | "tant" "que") test (":" | "faire" | "faire" ":") suite [("else" | "sinon") (":" | "faire" | "faire" ":") suite]
+for_stmt: ("for" | "pour") exprlist ("in" | "dans") testlist (":" | "faire" | "faire" ":") suite [("else" | "sinon") (":" | "faire" | "faire" ":") suite]
 try_stmt: ("try" ":" suite ((except_clause ":" suite)+ ["else" ":" suite] ["finally" ":" suite] | "finally" ":" suite))
 with_stmt: ("with") with_item ("," with_item)*  ":" suite
 with_item: test ["as" expr]

--- a/tests/tests_ast_parser/test_parser_for_stmt.py
+++ b/tests/tests_ast_parser/test_parser_for_stmt.py
@@ -22,7 +22,7 @@ else:
     b = a + 1
 """
     pseutopy_code = """
-for i in range(5) do:
+for i in range(5) do    :
     a = a + i
     print(a)
 else do set b to (a + 1)
@@ -55,7 +55,7 @@ for i in range(5):
         a = len(super_tab)
     else: print("There is something wrong here")
 else do:
-    while cmp < 5 do
+    while cmp < 5 do     :
         print(cmp)
         if (cmp-a)<2 then:
             set b to cmp

--- a/tests/tests_ast_parser/test_parser_if_stmt.py
+++ b/tests/tests_ast_parser/test_parser_if_stmt.py
@@ -25,9 +25,9 @@ else:
     b = 2
 """
     pseutopy_code = """
-if a is lower than b then
+if a is lower than b then    :
     set a to 2
-else then
+else then:
     set b to 2
 """
     assert pseutopy.convert_from_string(pseutopy_code) == python_code


### PR DESCRIPTION
- Fixed problem with whitespaces between `do`, `then` keywords and `:`.
- Did it for both `en.lark` and `fr.lark`
